### PR TITLE
Bugfix: Directory creation on init commands.

### DIFF
--- a/bin/commands/initialize.js
+++ b/bin/commands/initialize.js
@@ -1,6 +1,6 @@
 const inquirer = require('inquirer');
 const skeleton = require('../../config/marina-skeleton');
-const { setConfig, configFileExists, writeConfigFile } = require('../../lib/services/configuration');
+const { setConfig, configFileExists, writeNewConfigFile } = require('../../lib/services/configuration');
 
 module.exports = {
     command: 'initialize',
@@ -45,7 +45,7 @@ module.exports = {
         }
 
         if (writeFile) {
-            await writeConfigFile();
+            await writeNewConfigFile();
             process.stdout.write(`Wrote new Config file at ${argv.file}.`);
             return;
         }

--- a/lib/services/configuration.js
+++ b/lib/services/configuration.js
@@ -85,6 +85,13 @@ const writeConfigFile = async () => {
     return fs.writeFile(configFile, JSON.stringify(config, null, 2), {encoding:'utf8'});
 };
 
+const writeNewConfigFile = async () => {
+    const pathParts = configFile.split('/');
+    pathParts.pop();
+    await fs.mkdir(pathParts.join('/'), {recursive: true});
+    return writeConfigFile();
+};
+
 const setConfig = (cfg) => {
     config = cfg;
 };
@@ -100,5 +107,6 @@ module.exports = {
     selectApplications,
     applicationExists,
     writeConfigFile,
+    writeNewConfigFile,
     configFileExists,
 };


### PR DESCRIPTION
Previously, calling `marina init` and specifying a file within a directory that doesn't exist (including the default `~/.marina` directory), would fail.  This PR addresses that issue by creating parent directories recursively within that command only.